### PR TITLE
Fixed missing 'Debug' in 'Add graph'

### DIFF
--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -649,7 +649,7 @@ GraphConfig.load = function(config) {
         if (flightLog.isFieldEnabled().ACC) {
             EXAMPLE_GRAPHS.push({label: "Accelerometer",fields: ["accADC[all]"]});
         }
-        if (flightLog.isFieldEnabled().DEBUG) {
+        if (DEBUG_MODE[flightLog.getSysConfig().debug_mode] !== 'NONE') {
             EXAMPLE_GRAPHS.push({label: "Debug",fields: ["debug[all]"]});
         }
 


### PR DESCRIPTION
The 'Debug' graph was missing under 'Add graph' since there's no DEBUG field.