### PR TITLE
gyro_sample debug friendly names and gyro_type label and rates_type label

### DIFF
--- a/js/flightlog_fielddefs.js
+++ b/js/flightlog_fielddefs.js
@@ -393,10 +393,9 @@ var
     ]),
 
     FILTER_TYPE = makeReadOnly([
-        "PT1",
-        "BIQUAD",
-        "PT2",
-        "PT3",
+        "NONE", "FIRST_ORDER", "SECOND_ORDER",
+        "PT1", "PT2", "PT3",
+        "ORDER1", "BUTTER", "BESSEL", "DAMPED",
     ]),
 
     DEBUG_MODE = [],
@@ -772,6 +771,7 @@ var
     ]),
 
     RATES_TYPE = makeReadOnly([
+        "NONE",
         "BETAFLIGHT",
         "RACEFLIGHT",
         "KISS",

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -201,6 +201,17 @@ function FlightLogFieldPresenter() {
             'debug[2]':'Gyro Scaled [yaw]',
             'debug[3]':'Not Used',
         },
+        'GYRO_SAMPLE' : {
+            'debug[all]':'Gyro Sample [debug-axis]',
+            'debug[0]':'Gyro Raw',
+            'debug[1]':'Gyro Downsampled',
+            'debug[2]':'After RPM-filter',
+            'debug[3]':'After Lowpass',
+            'debug[4]':'After Static Notches',
+            'debug[5]':'After Dynamic Notches',
+            'debug[6]':'Not Used',
+            'debug[7]':'Not Used',
+        },
         'RC_COMMAND' : {
             'debug[all]':'Debug RC Command',
             'debug[0]':'Roll',
@@ -874,6 +885,7 @@ function FlightLogFieldPresenter() {
                 case 'GYRO':
                 case 'GYRO_FILTERED':
                 case 'GYRO_SCALED':
+                case 'GYRO_SAMPLE':
                 case 'NOTCH':
                 case 'DUAL_GYRO':
                 case 'DUAL_GYRO_COMBINED':

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -364,6 +364,7 @@ GraphConfig.load = function(config) {
                     case 'GYRO':
                     case 'GYRO_FILTERED':
                     case 'GYRO_SCALED':
+                    case 'GYRO_SAMPLE':
                     case 'DUAL_GYRO':
                     case 'DUAL_GYRO_COMBINED':
                     case 'DUAL_GYRO_DIFF':

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -667,7 +667,8 @@ function HeaderDialog(dialog, onSave) {
                 setParameter('gyro_lowpass_hz'                        ,sysConfig.gyro_lowpass_hz,0);
                 setParameter('gyro_lowpass2_hz'         ,sysConfig.gyro_lowpass2_hz,0);
 
-        if (activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.3.0')) {
+        if ((activeSysConfig.firmwareType == FIRMWARE_TYPE_ROTORFLIGHT) ||
+            (activeSysConfig.firmwareType == FIRMWARE_TYPE_BETAFLIGHT  && semver.gte(activeSysConfig.firmwareVersion, '4.3.0'))) {
             setParameter('dynNotchCount'           ,sysConfig.dyn_notch_count        , 0);
         } else {
             setParameter('dynNotchCount'           ,sysConfig.dyn_notch_width_percent, 0);


### PR DESCRIPTION
A bit of polishing:
1. GYRO_SAMPLE debug friendly names and scaling
2. fix missing dyn-notch count in header view
3. fix rates type label in header view
4. fix filter type lable in header and spectrum view
