### PR TITLE
Display collective in seekbar

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -141,6 +141,7 @@ function FlightLog(logData) {
         return {
             times: directory.times,
             avgThrottle: directory.avgThrottle,
+            collective: directory.collective,
             hasEvent: directory.hasEvent
         };
     };

--- a/js/flightlog_index.js
+++ b/js/flightlog_index.js
@@ -43,6 +43,7 @@ function FlightLogIndex(logData) {
                     times: [],
                     offsets: [],
                     avgThrottle: [],
+                    collective: [],
                     initialSlow: [],
                     initialGPSHome: [],
                     hasEvent: [],
@@ -90,6 +91,8 @@ function FlightLogIndex(logData) {
                     }
                 }
 
+                var collectiveIndex = mainFrameDef.nameToIndex["mixer[3]"] || mainFrameDef.nameToIndex["setpoint[3]"]
+
                 // Do we have mag fields? If not mark that data as absent
                 if (magADC[0] === undefined) {
                     magADC = false;
@@ -129,6 +132,8 @@ function FlightLogIndex(logData) {
 
                                         intraIndex.avgThrottle.push(Math.round(throttleTotal / motorFields.length));
                                     }
+
+                                    intraIndex.collective.push(collectiveIndex !== undefined ? frame[collectiveIndex] : 0)
 
                                     /* To enable seeking to an arbitrary point in the log without re-reading anything
                                      * that came before, we have to record the initial state of various items which aren't

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -286,6 +286,7 @@ var FlightLogParser = function(logData) {
             features:null,                          // Activated features (e.g. MOTORSTOP etc)
             Craft_name:null,                        // Craft Name
             motorOutput:[null,null],                // Minimum and maximum outputs to motor's
+            collectiveRange:[-1000,1000],           // Minimum and maximum collective outputs (raw)
             digitalIdleOffset:null,                 // min throttle for d-shot (as a percentage)
             pidSumLimit:null,                       // PID sum limit
             pidSumLimitYaw:null,                    // PID sum limit yaw

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -286,7 +286,7 @@ var FlightLogParser = function(logData) {
             features:null,                          // Activated features (e.g. MOTORSTOP etc)
             Craft_name:null,                        // Craft Name
             motorOutput:[null,null],                // Minimum and maximum outputs to motor's
-            collectiveRange:[-1500,1500],           // Minimum and maximum collective outputs (raw 1000 equals 12 deg)
+            collectiveRange:[-1250,1250],           // Minimum and maximum collective outputs (raw 1000 equals 12 deg)
             digitalIdleOffset:null,                 // min throttle for d-shot (as a percentage)
             pidSumLimit:null,                       // PID sum limit
             pidSumLimitYaw:null,                    // PID sum limit yaw

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -286,7 +286,7 @@ var FlightLogParser = function(logData) {
             features:null,                          // Activated features (e.g. MOTORSTOP etc)
             Craft_name:null,                        // Craft Name
             motorOutput:[null,null],                // Minimum and maximum outputs to motor's
-            collectiveRange:[-1000,1000],           // Minimum and maximum collective outputs (raw)
+            collectiveRange:[-1500,1500],           // Minimum and maximum collective outputs (raw 1000 equals 12 deg)
             digitalIdleOffset:null,                 // min throttle for d-shot (as a percentage)
             pidSumLimit:null,                       // PID sum limit
             pidSumLimitYaw:null,                    // PID sum limit yaw
@@ -826,6 +826,7 @@ var FlightLogParser = function(logData) {
             case "levelPID":
             case "velPID":
             case "motorOutput":
+            case "collectiveRange":
             case "rate_limits":
             case "rc_smoothing_cutoffs":
             case "rc_smoothing_active_cutoffs":

--- a/js/main.js
+++ b/js/main.js
@@ -421,12 +421,12 @@ function BlackboxLogViewer() {
         $('.lograte', statusBar).text( ((sysConfig['frameIntervalPDenom']!=null && sysConfig['frameIntervalPNum']!=null)?( 'Sample Rate : ' + sysConfig['frameIntervalPNum'] +'/' + sysConfig['frameIntervalPDenom']):''));
 
         seekBar.setTimeRange(flightLog.getMinTime(), flightLog.getMaxTime(), currentBlackboxTime);
-        seekBar.setActivityRange(flightLog.getSysConfig().motorOutput[0], flightLog.getSysConfig().motorOutput[1]);
+        seekBar.setActivityRange(flightLog.getSysConfig().collectiveRange[0], flightLog.getSysConfig().collectiveRange[1]);
 
         var
             activity = flightLog.getActivitySummary();
 
-        seekBar.setActivity(activity.times, activity.avgThrottle, activity.hasEvent);
+        seekBar.setActivity(activity.times, activity.collective, activity.hasEvent);
 
         seekBar.repaint();
     }


### PR DESCRIPTION
Display collective inputs in seekbar at the bottom (sourced from `mixer[3]` or `setpoint[3]` or 0 if none present).

![collective_seekbar](https://github.com/rotorflight/rotorflight-blackbox/assets/1812055/9ced2254-777c-4599-b9c6-04d2c5b98398)
