### PR TITLE
Display four harmonics markers in spectrum view

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -813,7 +813,7 @@ function FlightLogFieldPresenter() {
 
             case 'headspeed':
             case 'tailspeed':
-                    return (value).toFixed(0) + " rpm";
+                    return (value).toFixed(0) + " rpm (" + (value / 60).toFixed(1) + " Hz)";
 
             case 'motor[0]':
             case 'motor[1]':

--- a/js/graph_spectrum_calc.js
+++ b/js/graph_spectrum_calc.js
@@ -373,7 +373,7 @@ GraphSpectrumCalc._normalizeFft = function(fftOutput, fftLength) {
 
     // Make all the values absolute, and calculate some useful values (max noise, etc.)
     var maxFrequency = (this._blackBoxRate / 2.0);
-    var noiseLowEndIdx = 100 / maxFrequency * fftLength;
+    var noiseLowEndIdx = 25 / maxFrequency * fftLength;
     var maxNoiseIdx = 0;
     var maxNoise = 0;
 

--- a/js/graph_spectrum_plot.js
+++ b/js/graph_spectrum_plot.js
@@ -344,7 +344,7 @@ GraphSpectrumPlot._drawFiltersAndMarkers = function(canvasCtx) {
     const WIDTH  = this._canvasCtx.canvas.width - this._getActualMarginLeft();
     const PLOTTED_BLACKBOX_RATE = this._fftData.blackBoxRate / this._zoomX;
 
-    let offset = 2; // make some space! Includes the space for the mouse frequency. In this way the other elements don't move in the screen when used
+    let offset = 3; // make some space! Includes the space for the mouse frequency. In this way the other elements don't move in the screen when used
 
     // Gyro filters
     if (this._overdrawType === SPECTRUM_OVERDRAW_TYPE.ALL_FILTERS ||
@@ -449,7 +449,7 @@ GraphSpectrumPlot._drawFiltersAndMarkers = function(canvasCtx) {
     }
 
     if (this._spectrumType === SPECTRUM_TYPE.FREQUENCY) {
-        this._drawInterestFrequency(canvasCtx, this._fftData.maxNoiseIdx, PLOTTED_BLACKBOX_RATE, 'Max motor noise', WIDTH, HEIGHT, (15 * offset) + MARGIN, "rgba(255,0,0,0.50)", 3);
+        this._drawInterestFrequency(canvasCtx, this._fftData.maxNoiseIdx, PLOTTED_BLACKBOX_RATE, 'Max noise', WIDTH, HEIGHT, (15 * offset) + MARGIN, "rgba(255,0,0,0.33)", 3);
         offset++;
     }
 
@@ -634,6 +634,11 @@ GraphSpectrumPlot._drawGradientBackground = function(canvasCtx, WIDTH, HEIGHT) {
     canvasCtx.fillRect(0, 0, WIDTH, HEIGHT + ((this._isFullScreen) ? MARGIN : 0));
 };
 
+GraphSpectrumPlot._drawRpmFrequency = function(canvasCtx, frequency, sampleRate, label, WIDTH, HEIGHT, OFFSET, stroke, lineWidth) {
+    const interestLabel = `${frequency.toFixed(1)}Hz${label}`;
+    return this._drawVerticalMarkerLine(canvasCtx, frequency, sampleRate / 2, interestLabel, WIDTH, HEIGHT, OFFSET, stroke, lineWidth);
+};
+
 GraphSpectrumPlot._drawInterestFrequency = function(canvasCtx, frequency, sampleRate, label, WIDTH, HEIGHT, OFFSET, stroke, lineWidth) {
     const interestLabel = `${label} ${frequency.toFixed(1)}Hz`;
     return this._drawVerticalMarkerLine(canvasCtx, frequency, sampleRate / 2, interestLabel, WIDTH, HEIGHT, OFFSET, stroke, lineWidth);
@@ -749,16 +754,16 @@ GraphSpectrumPlot._drawMousePosition = function(canvasCtx, mouseX, mouseY, WIDTH
 
         const mouseFrequency = ((mouseX - marginLeft) / WIDTH) * ((this._fftData.blackBoxRate / this._zoomX) / 2);
         if (mouseFrequency >= 0 && mouseFrequency <= sampleRate) {
-            this._drawInterestFrequency(canvasCtx, mouseFrequency, sampleRate, '', WIDTH, HEIGHT, OFFSET, "rgba(0,255,0,0.66)", 1);
+            this._drawRpmFrequency(canvasCtx, mouseFrequency, sampleRate, ` (${Math.round(mouseFrequency * 60)}rpm)`, WIDTH, HEIGHT, OFFSET, "rgba(0,255,0,0.66)", 1);
         }
         if (mouseFrequency >= 0 && mouseFrequency * 2 <= sampleRate) {
-            this._drawInterestFrequency(canvasCtx, mouseFrequency * 2, sampleRate, '', WIDTH, HEIGHT, OFFSET, "rgba(0,255,0,0.66)", 1);
+            this._drawRpmFrequency(canvasCtx, mouseFrequency * 2, sampleRate, '', WIDTH, HEIGHT, OFFSET + 15, "rgba(0,255,0,0.66)", 1);
         }
         if (mouseFrequency >= 0 && mouseFrequency * 3 <= sampleRate) {
-            this._drawInterestFrequency(canvasCtx, mouseFrequency * 3, sampleRate, '', WIDTH, HEIGHT, OFFSET, "rgba(0,255,0,0.66)", 1);
+            this._drawRpmFrequency(canvasCtx, mouseFrequency * 3, sampleRate, '', WIDTH, HEIGHT, OFFSET + 15, "rgba(0,255,0,0.66)", 1);
         }
         if (mouseFrequency >= 0 && mouseFrequency * 4 <= sampleRate) {
-            this._drawInterestFrequency(canvasCtx, mouseFrequency * 4, sampleRate, '', WIDTH, HEIGHT, OFFSET, "rgba(0,255,0,0.66)", 1);
+            this._drawRpmFrequency(canvasCtx, mouseFrequency * 4, sampleRate, '', WIDTH, HEIGHT, OFFSET + 15, "rgba(0,255,0,0.66)", 1);
         }
 
         // Y axis

--- a/js/graph_spectrum_plot.js
+++ b/js/graph_spectrum_plot.js
@@ -749,7 +749,16 @@ GraphSpectrumPlot._drawMousePosition = function(canvasCtx, mouseX, mouseY, WIDTH
 
         const mouseFrequency = ((mouseX - marginLeft) / WIDTH) * ((this._fftData.blackBoxRate / this._zoomX) / 2);
         if (mouseFrequency >= 0 && mouseFrequency <= sampleRate) {
-            this._drawInterestFrequency(canvasCtx, mouseFrequency, sampleRate, '', WIDTH, HEIGHT, OFFSET, "rgba(0,255,0,0.50)", 3);
+            this._drawInterestFrequency(canvasCtx, mouseFrequency, sampleRate, '', WIDTH, HEIGHT, OFFSET, "rgba(0,255,0,0.66)", 1);
+        }
+        if (mouseFrequency >= 0 && mouseFrequency * 2 <= sampleRate) {
+            this._drawInterestFrequency(canvasCtx, mouseFrequency * 2, sampleRate, '', WIDTH, HEIGHT, OFFSET, "rgba(0,255,0,0.66)", 1);
+        }
+        if (mouseFrequency >= 0 && mouseFrequency * 3 <= sampleRate) {
+            this._drawInterestFrequency(canvasCtx, mouseFrequency * 3, sampleRate, '', WIDTH, HEIGHT, OFFSET, "rgba(0,255,0,0.66)", 1);
+        }
+        if (mouseFrequency >= 0 && mouseFrequency * 4 <= sampleRate) {
+            this._drawInterestFrequency(canvasCtx, mouseFrequency * 4, sampleRate, '', WIDTH, HEIGHT, OFFSET, "rgba(0,255,0,0.66)", 1);
         }
 
         // Y axis


### PR DESCRIPTION
Super simple, but saves a lot of time during analysis.
1. shift+mouse display additional bars with 2nd,3th and 4th harmonics
2. first bar as fundamental shows corresponding rpm
3. headspeed and tailspeed legend also show coresponding frequency

![bbox_spectrum_4_harmonics](https://github.com/rotorflight/rotorflight-blackbox/assets/1812055/94dfe81a-2f02-41e1-967f-44d27a6f0153)
