### PR TITLE
Voltage and current headers fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -2063,10 +2063,6 @@
                                         <table class="parameter cf">
                                             <tbody>
                                                 <tr>
-                                                    <td name="vbat_sag_compensation">
-                                                        <label>Vbat Sag Comp</label>
-                                                        <input type="text" step="1" min="0" max="150" />
-                                                    </td>
                                                     <td name="vbatmaxcellvoltage">
                                                         <label>Max Cell Voltage</label>
                                                         <input type="text" step="0.01" min="0" max="1.00" />
@@ -2078,6 +2074,9 @@
                                                     <td name="vbatwarningcellvoltage">
                                                         <label>Warning Voltage</label>
                                                         <input type="text" step="0.01" min="0" max="2.55" />
+                                                    </td>
+                                                    <td>
+                                                        &nbsp;
                                                     </td>
                                                 </tr>
                                             </tbody>
@@ -2106,26 +2105,6 @@
                                             </tbody>
                                         </table>
 
-                                        <table class="noline bf-only" cellpadding="0" cellspacing="0">
-                                            <tbody class="static-features misc noline">
-                                                <tr>
-                                                    <td name="vbat_pid_compensation">
-                                                        <label class="option">
-                                                            <input class="ios-switch orange" type="checkbox" />
-                                                            <div>
-                                                                <div></div>
-                                                            </div>
-                                                        </label>
-                                                    </td>
-                                                    <td>
-                                                        <label>Vat PID compensation</label>
-                                                    </td>
-                                                    <td>
-                                                        <span>Scale PIDs with voltage</span>
-                                                    </td>
-                                                </tr>
-                                            </tbody>
-                                        </table>
                                     </div>
                                 </div>
 

--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -261,7 +261,7 @@ function FlightLog(logData) {
         }
 
         //Are we even logging VBAT?
-        if (!fieldNameToIndex.vbatLatest) {
+        if (!fieldNameToIndex.Vbat) {
             numCells = false;
         } else {
             for (i = 1; i < 8; i++) {

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -788,9 +788,8 @@ function FlightLogFieldPresenter() {
             case 'accADC[2]':
                 return flightLog.accRawToGs(value).toFixed(2) + "g";
 
-                return (value / 100).toFixed(2) + "V";
-
             case 'Vbat':
+                return (value / 100).toFixed(2) + "V (" + (value / 100 / flightLog.getNumCellsEstimate()).toFixed(2) + " V/cell)";
             case 'Vbec':
             case 'Vbus':
                 return (value / 100).toFixed(2) + "V";

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -265,7 +265,6 @@ var FlightLogParser = function(logData) {
             baro_hardware:null,                     // Barometer Hardware type
             mag_hardware:null,                      // Magnetometer Hardware type
             gyro_cal_on_first_arm:null,             // Gyro Calibrate on first arm
-            vbat_pid_compensation:null,             // VBAT PID compensation
             rate_limits:[null, null, null],         // RC Rate limits
             rc_smoothing:null,                      // RC Control Smoothing
             rc_interpolation:null,                  // RC Control Interpolation type
@@ -308,7 +307,6 @@ var FlightLogParser = function(logData) {
             dyn_notch_max_hz: null,                 // Dyn Notch max limit in Hz for the filter
             rates_type: null,
             fields_mask: null,
-            vbat_sag_compensation: null,
             gyro_to_use: null,
             dynamic_idle_min_rpm: null,
             motor_poles: 1,
@@ -404,7 +402,6 @@ var FlightLogParser = function(logData) {
             tpa_rate                  : "dynThrPID",
             use_unsynced_pwm          : "unsynced_fast_pwm",
             vbat_scale                : "vbatscale",
-            vbat_pid_gain             : "vbat_pid_compensation",
             yaw_accel_limit           : "yawRateAccelLimit",
             yaw_lowpass_hz            : "yaw_lpf_hz",
             feedforward_transition    : "ff_transition",
@@ -640,7 +637,6 @@ var FlightLogParser = function(logData) {
             case "baro_hardware":
             case "mag_hardware":
             case "gyro_cal_on_first_arm":
-            case "vbat_pid_compensation":
             case "rc_smoothing":
             case "rc_smoothing_type":
             case "rc_smoothing_debug_axis":
@@ -708,7 +704,6 @@ var FlightLogParser = function(logData) {
             case "dyn_notch_min_hz":
             case "dyn_notch_max_hz":
             case "rates_type":
-            case "vbat_sag_compensation":
             case "fields_mask":
             case "motor_pwm_protocol":
             case "gyro_to_use":

--- a/js/grapher.js
+++ b/js/grapher.js
@@ -228,7 +228,7 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftCanv
                 idents.servoFields[servoIndex] = fieldIndex;
             } else {
                 switch (fieldName) {
-                    case "vbatLatest":
+                    case "Vbat":
                         idents.vbatField = fieldIndex;
                         idents.numCells = flightLog.getNumCellsEstimate();
                     break;

--- a/js/header_dialog.js
+++ b/js/header_dialog.js
@@ -27,7 +27,6 @@ function HeaderDialog(dialog, onSave) {
         {name:'rcYawRate'                    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.8.0', max:'999.9.9'},
         {name:'airmode_activate_throttle'    , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.8.0', max:'999.9.9'},
         {name:'rollPitchItermIgnoreRate'     , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.8.0', max:'3.0.1'},
-        {name:'vbat_pid_compensation'        , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.8.0', max:'4.2.999'},
         {name:'yawItermIgnoreRate'           , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'2.8.0', max:'3.0.1'},
         {name:'gyro_notch_hz'                , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
         {name:'gyro_notch_cutoff'            , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'3.0.0', max:'999.9.9'},
@@ -92,7 +91,6 @@ function HeaderDialog(dialog, onSave) {
         {name:'dyn_notch_max_hz'             , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.2.0', max:'999.9.9'},
         {name:'rates_type'                   , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.2.0', max:'999.9.9'},
         {name:'fields_disabled_mask'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
-        {name:'vbat_sag_compensation'        , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'gyro_to_use'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'dynamic_idle_min_rpm'         , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
         {name:'motor_poles'                  , type:FIRMWARE_TYPE_BETAFLIGHT,  min:'4.3.0', max:'999.9.9'},
@@ -591,10 +589,10 @@ function HeaderDialog(dialog, onSave) {
         setParameter('rcYawRate'                ,sysConfig.rc_rates[2],2);
         setParameter('rcYawExpo'                ,sysConfig.rc_expo[2],2);
         setParameter('vbatscale'                                ,sysConfig.vbatscale,0);
-        setParameter('vbatref'                                        ,sysConfig.vbatref,0);
-        setParameter('vbatmincellvoltage'                ,sysConfig.vbatmincellvoltage,1);
-        setParameter('vbatmaxcellvoltage'                ,sysConfig.vbatmaxcellvoltage,1);
-        setParameter('vbatwarningcellvoltage'        ,sysConfig.vbatwarningcellvoltage,1);
+        setParameter('vbatref'                                        ,sysConfig.vbatref,2);
+        setParameter('vbatmincellvoltage'                ,sysConfig.vbatmincellvoltage,2);
+        setParameter('vbatmaxcellvoltage'                ,sysConfig.vbatmaxcellvoltage,2);
+        setParameter('vbatwarningcellvoltage'        ,sysConfig.vbatwarningcellvoltage,2);
         setParameter('minthrottle'                                ,sysConfig.minthrottle,0);
         setParameter('maxthrottle'                                ,sysConfig.maxthrottle,0);
         setParameter('currentMeterOffset'                ,sysConfig.currentMeterOffset,0);
@@ -804,8 +802,6 @@ function HeaderDialog(dialog, onSave) {
                 setParameter('pidSumLimit'                             ,sysConfig.pidSumLimit,0);
         setParameter('pidSumLimitYaw'                        ,sysConfig.pidSumLimitYaw,0);
 
-        setParameter('vbat_sag_compensation'    ,sysConfig.vbat_sag_compensation,0);
-
         setParameter('dynamic_idle_min_rpm'     , sysConfig.dynamic_idle_min_rpm, 0);
         setParameter('dyn_idle_p_gain'          , sysConfig.dyn_idle_p_gain, 0);
         setParameter('dyn_idle_i_gain'          , sysConfig.dyn_idle_i_gain, 0);
@@ -882,7 +878,6 @@ function HeaderDialog(dialog, onSave) {
 
                 /* Booleans */
         setCheckbox('gyro_cal_on_first_arm'                ,sysConfig.gyro_cal_on_first_arm);
-        setCheckbox('vbat_pid_compensation'                ,sysConfig.vbat_pid_compensation);
         setCheckbox('rc_smoothing'                                ,sysConfig.rc_smoothing);
 
         /* Selected Fields */


### PR DESCRIPTION
1. fix cell count detection from vbatref header
2. display cell voltage in legend
3. display real values in `voltage & current` section
4. remove `vbat_sag_compensation` and `vbat_pid_compensation`

![bbox_vbat_fix](https://github.com/rotorflight/rotorflight-blackbox/assets/1812055/8304d5d9-78a5-4eea-8474-3cff5c4f17a8)