### PR TITLE
Linux mime file fix

### DIFF
--- a/assets/linux/mime/rotorflight-blackbox.xml
+++ b/assets/linux/mime/rotorflight-blackbox.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
    <mime-type type="application/x-blackboxlog">
-     <comment>Betaflight Blackbox log file</comment>
+     <comment>Rotorflight Blackbox log file</comment>
      <glob pattern="*.BBL"/>
      <glob pattern="*.BFL"/>
    </mime-type>


### PR DESCRIPTION
fixes warnings during installation of .deb version
```
rm: cannot remove '/usr/share/mime/packages/rotorflight-blackbox.xml': No such file or directory
cp: cannot stat '/opt/rotorflight/rotorflight-blackbox/mime/rotorflight-blackbox.xml': No such file or directory
```