### PR TITLE
HSI O-term to PID groups and B-term names

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -26,6 +26,16 @@ function FlightLogFieldPresenter() {
         'axisF[1]': 'PID Feedforward [pitch]',
         'axisF[2]': 'PID Feedforward [yaw]',
 
+        'axisB[all]': 'PID Boost',
+        'axisB[0]': 'PID Boost [roll]',
+        'axisB[1]': 'PID Boost [pitch]',
+        'axisB[2]': 'PID Boost [yaw]',
+
+        'axisO[all]': 'PID Offset',
+        'axisO[0]': 'PID Offset [roll]',
+        'axisO[1]': 'PID Offset [pitch]',
+        'axisO[2]': 'PID Offset [yaw]',
+
         //Virtual field
         'axisSum[all]': 'PID Sum',
         'axisSum[0]' : 'PID Sum [roll]',

--- a/js/graph_config.js
+++ b/js/graph_config.js
@@ -660,9 +660,9 @@ GraphConfig.load = function(config) {
             EXAMPLE_GRAPHS.push({label: "Controls",fields: ["mixer[all]"]});
         }
         if (flightLog.isFieldEnabled().PID) {
-            EXAMPLE_GRAPHS.push({label: "PID roll",fields: ["axisP[0]", "axisI[0]", "axisD[0]", "axisF[0]", "axisSum[0]", "gyroADC[0]", "setpoint[0]"]},
-                                {label: "PID pitch",fields: ["axisP[1]", "axisI[1]", "axisD[1]", "axisF[1]", "axisSum[1]", "gyroADC[1]", "setpoint[1]"]},
-                                {label: "PID yaw",fields: ["axisP[2]", "axisI[2]", "axisD[2]", "axisF[2]", "axisSum[2]", "gyroADC[2]", "setpoint[2]"]});
+            EXAMPLE_GRAPHS.push({label: "PID roll",fields: ["axisP[0]", "axisI[0]", "axisD[0]", "axisF[0]", "axisSum[0]", "gyroADC[0]", "setpoint[0]", "axisO[0]"]},
+                                {label: "PID pitch",fields: ["axisP[1]", "axisI[1]", "axisD[1]", "axisF[1]", "axisSum[1]", "gyroADC[1]", "setpoint[1]", "axisO[1]"]},
+                                {label: "PID yaw",fields: ["axisP[2]", "axisI[2]", "axisD[2]", "axisF[2]", "axisSum[2]", "gyroADC[2]", "setpoint[2]", "axisO[2]"]});
         }
         if (flightLog.isFieldEnabled().RPM) {
             EXAMPLE_GRAPHS.push({label: "Rotor Speeds",fields: ["headspeed", "tailspeed"]});


### PR DESCRIPTION
Fixes #34 

@rotorflight do you prefer to place it at the end `PID group` or between `axisF` and `axisSum`. Second seems more logical, but there will be impact on color assignment. At the moment I decided to add at the end.

Also I added missing Boost label here.