### PR TITLE
fix (marker): improved timespan and frequency notation

### DIFF
--- a/js/grapher.js
+++ b/js/grapher.js
@@ -632,12 +632,12 @@ function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, craftWrap
                         }, sequenceNum++);
                 };
 
-                var markerFrequency = ((windowCenterTime-markerEvent.time).toFixed(0)!=0)?((1000000/(windowCenterTime-markerEvent.time)).toFixed(0) + "Hz") : '';
+                var markerFrequency = ((windowCenterTime-markerEvent.time).toFixed(0)!=0) ? ' (' + ((1000000/(windowCenterTime-markerEvent.time)).toFixed(1) + "Hz)") : '';
                 drawEvent(
                     {
                     event:FlightLogEvent.CUSTOM_BLANK, // Blank doesnt show a vertical line
                     time:windowCenterTime,
-                    label: formatTime((windowCenterTime-markerEvent.time)/1000, true) + 'ms ' + markerFrequency,
+                    label: formatTime((windowCenterTime-markerEvent.time)/1000, true) + markerFrequency,
                     align:(markerEvent.time<windowCenterTime)?'right':'left',
                     }, sequenceNum++);
             };

--- a/js/main.js
+++ b/js/main.js
@@ -236,7 +236,7 @@ function BlackboxLogViewer() {
             // update time field on status bar
             $(".graph-time").val(formatTime((currentBlackboxTime-flightLog.getMinTime())/1000, true));
             if(hasMarker) {
-                $(".marker-offset", statusBar).text('Marker Offset ' + formatTime((currentBlackboxTime-markerTime)/1000, true) + 'ms ' + (1000000/(currentBlackboxTime-markerTime)).toFixed(0) + "Hz");
+                $(".marker-offset", statusBar).text('Marker Offset ' + formatTime((currentBlackboxTime-markerTime)/1000, true) + ' (' + (1000000/(currentBlackboxTime-markerTime)).toFixed(0) + "Hz)");
             }
 
             // Update the Legend Values
@@ -1792,7 +1792,7 @@ function BlackboxLogViewer() {
                         } else { // Add a marker to graph window
                             markerTime = currentBlackboxTime;
                             setMarker(!hasMarker);
-                            $(".marker-offset", statusBar).text('Marker Offset ' + formatTime(0) + 'ms').css('visibility', (hasMarker)?'visible':'hidden');
+                            $(".marker-offset", statusBar).text('Marker Offset ' + formatTime(0)).css('visibility', (hasMarker)?'visible':'hidden');
                             invalidateGraph();
                         }
                         e.preventDefault();


### PR DESCRIPTION
Improved marker notation:
- deleted 'ms' postfix
- added braces and one decimal to frequency

![image](https://github.com/user-attachments/assets/6ab869e6-a88e-45b7-bf69-6b303b094a7a)
