### PR TITLE
Debug parameter names update

### DIFF
--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -649,6 +649,32 @@ function FlightLogFieldPresenter() {
 
         DEBUG_FRIENDLY_FIELD_NAMES = {...DEBUG_FRIENDLY_FIELD_NAMES_INITIAL};
 
+        if (firmwareType === FIRMWARE_TYPE_ROTORFLIGHT) {
+           if (semver.gte(firmwareVersion, '4.3.0')) {
+        	DEBUG_FRIENDLY_FIELD_NAMES.ITERM_RELAX = {
+                    'debug[all]':'I-term Relax new',
+                    'debug[0]':'Setpoint',
+                    'debug[1]':'Gyro Rate',
+                    'debug[2]':'Setpoint LPF',
+                    'debug[3]':'Setpoint HPF',
+                    'debug[4]':'I Relax Factor',
+                    'debug[5]':'Relaxed I Error',
+                };
+           };
+           if (semver.gte(firmwareVersion, '4.5.0')) {
+                DEBUG_FRIENDLY_FIELD_NAMES.YAW_PRECOMP = {
+		    'debug[all]':'Yaw Precompensation',
+		    'debug[0]':'Total Precompensation',
+		    'debug[1]':'Main Precompensation',
+		    'debug[2]':'Main Deflection',
+		    'debug[3]':'Collective Deflection',
+		    'debug[4]':'Cyclic Deflection',
+		    'debug[6]':'Speed Change',
+		    'debug[7]':'Torque Precompensation',
+        	};
+            };
+        };
+        
         if (firmwareType === FIRMWARE_TYPE_BETAFLIGHT) {
             if (semver.gte(firmwareVersion, '4.3.0')) {
                 DEBUG_FRIENDLY_FIELD_NAMES.FEEDFORWARD = {
@@ -1090,6 +1116,21 @@ function FlightLogFieldPresenter() {
                     }
                     break;
                 case 'ITERM_RELAX':
+                    if (flightLog.getSysConfig().firmwareType === FIRMWARE_TYPE_ROTORFLIGHT && semver.gte(flightLog.getSysConfig().firmwareVersion, '4.3.0')) {
+	                    switch (fieldName) {
+	                           case 'debug[0]': // setpoint
+	                           case 'debug[1]': // Gyro Rate
+	                           case 'debug[2]': // setpoint low-pass filtered
+	                           case 'debug[3]': // setpoint high-pass filtered
+	                                return (value / 1000).toFixed(0) + '°/s';
+	                           case 'debug[4]': // I-term relax factor
+	                                return (value / 10).toFixed(0) + '%';
+	                           case 'debug[5]': // Relaxed I Error
+	                                return (value / 1000).toFixed(1);
+	                    }
+                    	break;
+					}
+                    // else
                     switch (fieldName) {
                         case 'debug[0]': // roll setpoint high-pass filtered
                             return value.toFixed(0) + '°/s';
@@ -1128,6 +1169,21 @@ function FlightLogFieldPresenter() {
                             return value.toFixed(0);
                     }
                 case 'YAW_PRECOMP':
+					if (flightLog.getSysConfig().firmwareType === FIRMWARE_TYPE_ROTORFLIGHT && semver.gte(flightLog.getSysConfig().firmwareVersion, '4.5.0')) {
+					    switch (fieldName) {
+							case 'debug[0]': // Total Precompensation
+							case 'debug[1]': // Main Precompensation
+							case 'debug[2]': // Main Deflection
+							case 'debug[3]': // Collective Deflection
+							case 'debug[4]': // Cyclic Deflection
+							case 'debug[7]': // Torque Precompensation
+								return (value / 10).toFixed(1) + '%';
+							case 'debug[6]': // Speed Change
+								return value.toFixed(0) + 'rpm';
+					    }
+						break;
+					}
+					// else
                     switch (fieldName) {
                         case 'debug[0]': // collective deflection
                         case 'debug[1]': // collective ff

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -641,6 +641,17 @@ function FlightLogFieldPresenter() {
             'debug[3]':'Minimum Throttle',
             'debug[5]':'Voltage Compensation Gain',
         },
+        'HS_OFFSET' : {
+            'debug[all]':'HS Offset',
+            'debug[0]':'erroRate',
+            'debug[1]':'itermErrorRate',
+            'debug[2]':'offMod',
+            'debug[3]':'offDelta',
+            'debug[4]':'axisError',
+            'debug[5]':'axisOffset',
+            'debug[6]':'O',
+            'debug[7]':'I',
+        },
     };
 
     let DEBUG_FRIENDLY_FIELD_NAMES = null;
@@ -652,26 +663,26 @@ function FlightLogFieldPresenter() {
         if (firmwareType === FIRMWARE_TYPE_ROTORFLIGHT) {
            if (semver.gte(firmwareVersion, '4.3.0')) {
         	DEBUG_FRIENDLY_FIELD_NAMES.ITERM_RELAX = {
-                    'debug[all]':'I-term Relax new',
-                    'debug[0]':'Setpoint',
-                    'debug[1]':'Gyro Rate',
-                    'debug[2]':'Setpoint LPF',
-                    'debug[3]':'Setpoint HPF',
-                    'debug[4]':'I Relax Factor',
-                    'debug[5]':'Relaxed I Error',
+                'debug[all]':'I-term Relax new',
+                'debug[0]':'Setpoint',
+                'debug[1]':'Gyro Rate',
+                'debug[2]':'Setpoint LPF',
+                'debug[3]':'Setpoint HPF',
+                'debug[4]':'I Relax Factor',
+                'debug[5]':'Relaxed I Error',
                 };
            };
            if (semver.gte(firmwareVersion, '4.5.0')) {
                 DEBUG_FRIENDLY_FIELD_NAMES.YAW_PRECOMP = {
-		    'debug[all]':'Yaw Precompensation',
-		    'debug[0]':'Total Precompensation',
-		    'debug[1]':'Main Precompensation',
-		    'debug[2]':'Main Deflection',
-		    'debug[3]':'Collective Deflection',
-		    'debug[4]':'Cyclic Deflection',
-		    'debug[6]':'Speed Change',
-		    'debug[7]':'Torque Precompensation',
-        	};
+                'debug[all]':'Yaw Precompensation',
+                'debug[0]':'Total Precompensation',
+                'debug[1]':'Main Precompensation',
+                'debug[2]':'Main Deflection',
+                'debug[3]':'Collective Deflection',
+                'debug[4]':'Cyclic Deflection',
+                'debug[6]':'Speed Change',
+                'debug[7]':'Torque Precompensation',
+                };   
             };
         };
         
@@ -1113,6 +1124,21 @@ function FlightLogFieldPresenter() {
                         case 'debug[2]': // roll actual D
                         case 'debug[3]': // pitch actual D
                             return (value / 10).toFixed(1);
+                    }
+                    break;
+                 case 'HS_OFFSET':
+                    switch (fieldName) {
+                        case 'debug[0]':
+                        case 'debug[1]':
+                        case 'debug[4]': 
+                        case 'debug[5]': 
+                            return (value / 10).toFixed(1) + '°/s';
+                        case 'debug[3]': // offset delta
+                            return (value / 1000).toFixed(2) + '%';
+                        case 'debug[2]': // offset Modulated
+                        case 'debug[6]': // PID Offset
+                        case 'debug[7]': // PID I
+                            return (value / 10).toFixed(1) + '%';
                     }
                     break;
                 case 'ITERM_RELAX':

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -676,30 +676,30 @@ function FlightLogFieldPresenter() {
 
         if (firmwareType === FIRMWARE_TYPE_ROTORFLIGHT) {
            if (semver.gte(firmwareVersion, '4.3.0')) {
-        	DEBUG_FRIENDLY_FIELD_NAMES.ITERM_RELAX = {
-                'debug[all]':'I-term Relax new',
-                'debug[0]':'Setpoint',
-                'debug[1]':'Gyro Rate',
-                'debug[2]':'Setpoint LPF',
-                'debug[3]':'Setpoint HPF',
-                'debug[4]':'I Relax Factor',
-                'debug[5]':'Relaxed I Error',
+                DEBUG_FRIENDLY_FIELD_NAMES.ITERM_RELAX = {
+                    'debug[all]':'I-term Relax',
+                    'debug[0]':'Setpoint',
+                    'debug[1]':'Gyro Rate',
+                    'debug[2]':'Setpoint LPF',
+                    'debug[3]':'Setpoint HPF',
+                    'debug[4]':'I Relax Factor',
+                    'debug[5]':'Relaxed I Error',
                 };
            };
            if (semver.gte(firmwareVersion, '4.5.0')) {
                 DEBUG_FRIENDLY_FIELD_NAMES.YAW_PRECOMP = {
-                'debug[all]':'Yaw Precompensation',
-                'debug[0]':'Total Precompensation',
-                'debug[1]':'Main Precompensation',
-                'debug[2]':'Main Deflection',
-                'debug[3]':'Collective Deflection',
-                'debug[4]':'Cyclic Deflection',
-                'debug[6]':'Speed Change',
-                'debug[7]':'Torque Precompensation',
-                };   
+                    'debug[all]':'Yaw Precompensation',
+                    'debug[0]':'Total Precompensation',
+                    'debug[1]':'Main Precompensation',
+                    'debug[2]':'Main Deflection',
+                    'debug[3]':'Collective Deflection',
+                    'debug[4]':'Cyclic Deflection',
+                    'debug[6]':'Speed Change',
+                    'debug[7]':'Torque Precompensation',
+                };
             };
         };
-        
+
         if (firmwareType === FIRMWARE_TYPE_BETAFLIGHT) {
             if (semver.gte(firmwareVersion, '4.3.0')) {
                 DEBUG_FRIENDLY_FIELD_NAMES.FEEDFORWARD = {
@@ -1144,8 +1144,8 @@ function FlightLogFieldPresenter() {
                     switch (fieldName) {
                         case 'debug[0]':
                         case 'debug[1]':
-                        case 'debug[4]': 
-                        case 'debug[5]': 
+                        case 'debug[4]':
+                        case 'debug[5]':
                             return (value / 10).toFixed(1) + '°/s';
                         case 'debug[3]': // offset delta
                             return (value / 1000).toFixed(2) + '%';
@@ -1160,14 +1160,14 @@ function FlightLogFieldPresenter() {
                         case 'debug[0]':
                         case 'debug[1]':
                             return (value / 10).toFixed(1) + '°/s^2';
-                        case 'debug[2]': 
-                        case 'debug[3]': 
+                        case 'debug[2]':
+                        case 'debug[3]':
                             return (value / 100).toFixed(1) + '%';
                     }
-                    break;                    
+                    break;
                 case 'ITERM_RELAX':
                     if (flightLog.getSysConfig().firmwareType === FIRMWARE_TYPE_ROTORFLIGHT && semver.gte(flightLog.getSysConfig().firmwareVersion, '4.3.0')) {
-	                    switch (fieldName) {
+                        switch (fieldName) {
 	                           case 'debug[0]': // setpoint
 	                           case 'debug[1]': // Gyro Rate
 	                           case 'debug[2]': // setpoint low-pass filtered
@@ -1177,9 +1177,9 @@ function FlightLogFieldPresenter() {
 	                                return (value / 10).toFixed(0) + '%';
 	                           case 'debug[5]': // Relaxed I Error
 	                                return (value / 1000).toFixed(1);
-	                    }
-                    	break;
-					}
+                        }
+                        break;
+                    }
                     // else
                     switch (fieldName) {
                         case 'debug[0]': // roll setpoint high-pass filtered
@@ -1219,21 +1219,21 @@ function FlightLogFieldPresenter() {
                             return value.toFixed(0);
                     }
                 case 'YAW_PRECOMP':
-					if (flightLog.getSysConfig().firmwareType === FIRMWARE_TYPE_ROTORFLIGHT && semver.gte(flightLog.getSysConfig().firmwareVersion, '4.5.0')) {
-					    switch (fieldName) {
-							case 'debug[0]': // Total Precompensation
-							case 'debug[1]': // Main Precompensation
-							case 'debug[2]': // Main Deflection
-							case 'debug[3]': // Collective Deflection
-							case 'debug[4]': // Cyclic Deflection
-							case 'debug[7]': // Torque Precompensation
-								return (value / 10).toFixed(1) + '%';
-							case 'debug[6]': // Speed Change
-								return value.toFixed(0) + 'rpm';
-					    }
-						break;
-					}
-					// else
+                    if (flightLog.getSysConfig().firmwareType === FIRMWARE_TYPE_ROTORFLIGHT && semver.gte(flightLog.getSysConfig().firmwareVersion, '4.5.0')) {
+                        switch (fieldName) {
+                            case 'debug[0]': // Total Precompensation
+                            case 'debug[1]': // Main Precompensation
+                            case 'debug[2]': // Main Deflection
+                            case 'debug[3]': // Collective Deflection
+                            case 'debug[4]': // Cyclic Deflection
+                            case 'debug[7]': // Torque Precompensation
+                                return (value / 10).toFixed(1) + '%';
+                            case 'debug[6]': // Speed Change
+                                return value.toFixed(0) + 'rpm';
+                        }
+                        break;
+                    }
+                    // else
                     switch (fieldName) {
                         case 'debug[0]': // collective deflection
                         case 'debug[1]': // collective ff

--- a/js/flightlog_fields_presenter.js
+++ b/js/flightlog_fields_presenter.js
@@ -652,6 +652,13 @@ function FlightLogFieldPresenter() {
             'debug[6]':'O',
             'debug[7]':'I',
         },
+        'CROSS_COUPLING' : {
+            'debug[all]':'Cross Coupling',
+            'debug[0]':'Roll Derivative',
+            'debug[1]':'Pitch Derivative',
+            'debug[2]':'Roll Compensation',
+            'debug[3]':'Pitch Compensation',
+        },
     };
 
     let DEBUG_FRIENDLY_FIELD_NAMES = null;
@@ -1141,6 +1148,16 @@ function FlightLogFieldPresenter() {
                             return (value / 10).toFixed(1) + '%';
                     }
                     break;
+                 case 'CROSS_COUPLING':
+                    switch (fieldName) {
+                        case 'debug[0]':
+                        case 'debug[1]':
+                            return (value / 10).toFixed(1) + '°/s^2';
+                        case 'debug[2]': 
+                        case 'debug[3]': 
+                            return (value / 100).toFixed(1) + '%';
+                    }
+                    break;                    
                 case 'ITERM_RELAX':
                     if (flightLog.getSysConfig().firmwareType === FIRMWARE_TYPE_ROTORFLIGHT && semver.gte(flightLog.getSysConfig().firmwareVersion, '4.3.0')) {
 	                    switch (fieldName) {


### PR DESCRIPTION
Aligned the names of the debug parameters recorded in the rotorflight-firmware.

Only addressed YAW_PRECOMP and ITERM_RELAX.