### PR TITLE
Fix lower batter display, currently limited to 8s

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -266,7 +266,7 @@ function FlightLog(logData) {
         if (!fieldNameToIndex.Vbat) {
             numCells = false;
         } else {
-            for (i = 1; i < 8; i++) {
+            for (i = 1; i < 14; i++) {
                 if (refVoltage < i * sysConfig.vbatmaxcellvoltage)
                     break;
             }


### PR DESCRIPTION
fixing the bug where only up to 8s batteries will display on the lower status bar, this fix supports displaying up 14s correctly