### PR TITLE
Fix Workspaces Appearing behind the seek bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,7 +438,7 @@
             </li>
             <li class="log-workspace-panel">
                 <h4>Workspace</h4>
-                <div class="log-workspace-selection"></div>
+                <div class="log-workspace-selection" id="workspace-open-close-id"></div>
             </li>
         </ul>
         <div id="screenshot-frame" class="graph-row">

--- a/js/main.js
+++ b/js/main.js
@@ -2158,4 +2158,29 @@ $(document).click(function (e) {
 // Boostrap's data API is extremely slow when there are a lot of DOM elements churning, don't use it
 $(document).off('.data-api');
 
+//Add a watch to the workspace selection div
+//As it gets the open class, send the seekbar to the background
+//Otherwise, bring the seekbar to the foreground
+const targetNode = document.getElementById('workspace-open-close-id');
+const observer = new MutationObserver((mutationsList) => {
+    for (const mutation of mutationsList) {
+        if (mutation.attributeName === 'class') {
+            const currentClassList = targetNode.className;
+            if (currentClassList && currentClassList.includes('open')){
+                    $('.log-seek-bar').css({
+                        'z-index': '-1',
+                        'pointer-events': 'none'
+                    });
+            }else{
+                    $('.log-seek-bar').css({
+                        'z-index': '1',
+                        'pointer-events': 'auto'
+                    });
+            }
+        }
+    }
+});
+
+observer.observe(targetNode, { attributes: true });
+
 window.blackboxLogViewer = new BlackboxLogViewer();


### PR DESCRIPTION
fixing issue where the prebuilt workspaces are hidden or behind the seek bar. With this change, the workspace dropdown is always in front of the seek bar, enabling the user to see all of the workspaces. 

Before fix,
<img width="360" height="203" alt="Before" src="https://github.com/user-attachments/assets/779cc257-441d-47bc-8183-d14a262e3ff5" />


After fix,
<img width="582" height="302" alt="After" src="https://github.com/user-attachments/assets/ae48860d-7aa0-4d76-af04-041ebe90934c" />
