### PR TITLE
Recover corrupted log gaps in viewer

### DIFF
--- a/js/flightlog.js
+++ b/js/flightlog.js
@@ -72,6 +72,16 @@ function FlightLog(logData) {
         }
     };
 
+    // Keep directory lookup in one place so callers consistently use the indexed view
+    // for either the active log or an explicitly requested log.
+    function getIntraframeDirectory(logIndex) {
+        if (logIndex === undefined) {
+            return iframeDirectory;
+        }
+
+        return logIndexes.getIntraframeDirectory(logIndex);
+    }
+
     /**
      * Get the stats for the log of the given index, or leave off the logIndex argument to fetch the stats
      * for the current log.
@@ -98,6 +108,12 @@ function FlightLog(logData) {
      * argument to fetch details for the current log.
      */
     this.getMinTime = function(logIndex) {
+        var directory = getIntraframeDirectory(logIndex);
+
+        if (directory && directory.minTime !== false) {
+            return directory.minTime;
+        }
+
         return getRawStats(logIndex).frame["I"].field[FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME].min;
     };
 
@@ -106,6 +122,12 @@ function FlightLog(logData) {
      * argument to fetch details for the current log.
      */
     this.getMaxTime = function(logIndex) {
+        var directory = getIntraframeDirectory(logIndex);
+
+        if (directory && directory.maxTime !== false) {
+            return directory.maxTime;
+        }
+
         return getRawStats(logIndex).frame["I"].field[FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME].max;
     };
 
@@ -142,6 +164,7 @@ function FlightLog(logData) {
             times: directory.times,
             avgThrottle: directory.avgThrottle,
             collective: directory.collective,
+            gaps: directory.gaps,
             hasEvent: directory.hasEvent,
             pidProfile: directory.pidProfile
         };

--- a/js/flightlog_index.js
+++ b/js/flightlog_index.js
@@ -8,6 +8,16 @@ function FlightLogIndex(logData) {
         logCount = false,
         intraframeDirectories = false;
 
+    function getExpectedChunkDuration(sysConfig) {
+        if (!sysConfig || !sysConfig.looptime || !sysConfig.frameIntervalI) {
+            return false;
+        }
+
+        var pidProcessDenom = sysConfig.pid_process_denom || 1;
+
+        return sysConfig.looptime * pidProcessDenom * sysConfig.frameIntervalI * 4;
+    }
+
     function buildLogOffsetsIndex() {
         var
             stream = new ArrayDataStream(logData),
@@ -44,6 +54,7 @@ function FlightLogIndex(logData) {
                     offsets: [],
                     avgThrottle: [],
                     collective: [],
+                    gaps: [],
                     initialSlow: [],
                     initialGPSHome: [],
                     hasEvent: [],
@@ -191,6 +202,25 @@ function FlightLogIndex(logData) {
                 }
 
                 intraIndex.stats = parser.stats;
+
+                var typicalChunkDuration = getExpectedChunkDuration(sysConfig);
+                var gapTolerance = typicalChunkDuration ? Math.round(typicalChunkDuration * 0.5) : false;
+
+                if (gapTolerance !== false) {
+                    for (var j = 1; j < intraIndex.times.length; j++) {
+                        var previousTime = intraIndex.times[j - 1];
+                        var currentTime = intraIndex.times[j];
+                        var delta = currentTime - previousTime;
+                        var missingTime = delta - typicalChunkDuration;
+
+                        if (missingTime > gapTolerance) {
+                            intraIndex.gaps.push({
+                                startTime: previousTime + typicalChunkDuration,
+                                endTime: currentTime
+                            });
+                        }
+                    }
+                }
             }
 
             // Did we not find any events in this log?

--- a/js/flightlog_parser.js
+++ b/js/flightlog_parser.js
@@ -1077,6 +1077,8 @@ var FlightLogParser = function(logData) {
 
     function invalidateMainStream() {
         mainStreamIsValid = false;
+        lastSkippedFrames = 0;
+        lastMainFrameIteration = -1;
 
         mainHistory[0] = mainHistoryRing ? mainHistoryRing[0]: null;
         mainHistory[1] = null;
@@ -1108,8 +1110,14 @@ var FlightLogParser = function(logData) {
     function completeIntraframe(frameType, frameStart, frameEnd, raw) {
         var acceptFrame = true;
 
-        // Do we have a previous frame to use as a reference to validate field values against?
-        if (!raw && lastMainFrameIteration != -1) {
+        if (!raw && lastMainFrameTime != -1) {
+            acceptFrame =
+                mainHistory[0][FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME] >= lastMainFrameTime
+                && mainHistory[0][FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME] < lastMainFrameTime + MAXIMUM_TIME_JUMP_BETWEEN_FRAMES;
+        }
+
+        // Do we have a previous valid iteration to use as a reference?
+        if (acceptFrame && !raw && lastMainFrameIteration != -1) {
             /*
              * Check that iteration count and time didn't move backwards, and didn't move forward too much.
              */
@@ -1308,7 +1316,7 @@ var FlightLogParser = function(logData) {
                     mainHistory[0][FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_TIME] > lastMainFrameTime + MAXIMUM_TIME_JUMP_BETWEEN_FRAMES
                     || mainHistory[0][FlightLogParser.prototype.FLIGHT_LOG_FIELD_INDEX_ITERATION] > lastMainFrameIteration + MAXIMUM_ITERATION_JUMP_BETWEEN_FRAMES
                 )) {
-            mainStreamIsValid = false;
+            invalidateMainStream();
         }
 
         if (mainStreamIsValid) {
@@ -1751,7 +1759,8 @@ var FlightLogParser = function(logData) {
             prematureEof = false,
             frameStart = 0,
             frameType = null,
-            lastFrameType = null;
+            lastFrameType = null,
+            frameParseError = null;
 
         invalidateMainStream();
 
@@ -1770,13 +1779,14 @@ var FlightLogParser = function(logData) {
                     frameTypeStats;
 
                 // Is this the beginning of a new frame?
-                looksLikeFrameCompleted = getFrameType(command) || (!prematureEof && command == EOF);
+                looksLikeFrameCompleted = !frameParseError && (getFrameType(command) || (!prematureEof && command == EOF));
 
                 if (!this.stats.frame[lastFrameType.marker]) {
                     this.stats.frame[lastFrameType.marker] = {
                         bytes: 0,
                         sizeCount: new Int32Array(256), /* int32 arrays are zero-filled, handy! */
                         validCount: 0,
+                        desyncCount: 0,
                         corruptCount: 0,
                         field: []
                     };
@@ -1799,11 +1809,13 @@ var FlightLogParser = function(logData) {
                     } else {
                         frameTypeStats.desyncCount++;
                     }
+
+                    frameParseError = null;
                 } else {
                     //The previous frame was corrupt
 
                     //We need to resynchronise before we can deliver another main frame:
-                    mainStreamIsValid = false;
+                    invalidateMainStream();
                     frameTypeStats.corruptCount++;
                     this.stats.totalCorruptFrames++;
 
@@ -1818,6 +1830,7 @@ var FlightLogParser = function(logData) {
                      */
                     stream.pos = frameStart + 1;
                     lastFrameType = null;
+                    frameParseError = null;
                     prematureEof = false;
                     stream.eof = false;
                     continue;
@@ -1833,15 +1846,22 @@ var FlightLogParser = function(logData) {
             // Reject the frame if it is one that we have no definitions for in the header
             if (frameType && (command == 'E' || that.frameDefs[command])) {
                 lastFrameType = frameType;
-                frameType.parse(raw);
+                frameParseError = null;
+
+                try {
+                    frameType.parse(raw);
+                } catch (error) {
+                    frameParseError = error;
+                }
 
                 //We shouldn't read an EOF during reading a frame (that'd imply the frame was truncated)
-                if (stream.eof) {
+                if (!frameParseError && stream.eof) {
                     prematureEof = true;
                 }
             } else {
-                mainStreamIsValid = false;
+                invalidateMainStream();
                 lastFrameType = null;
+                frameParseError = null;
             }
         }
 

--- a/js/main.js
+++ b/js/main.js
@@ -426,7 +426,7 @@ function BlackboxLogViewer() {
         var
             activity = flightLog.getActivitySummary();
 
-        seekBar.setActivity(activity.times, activity.collective, activity.hasEvent, activity.pidProfile);
+        seekBar.setActivity(activity.times, activity.collective, activity.hasEvent, activity.pidProfile, activity.gaps);
 
         seekBar.repaint();
     }

--- a/js/seekbar.js
+++ b/js/seekbar.js
@@ -13,6 +13,9 @@ function SeekBar(canvas) {
         //Whether a special event exists at the given time:
         hasEvent,
 
+        //Corrupt or empty time spans to highlight:
+        gaps,
+
         //PID profile state at the given time:
         pidProfile,
 
@@ -34,6 +37,7 @@ function SeekBar(canvas) {
         dirtyRegion = false,
 
         BACKGROUND_STYLE = '#eee',
+        GAP_STYLE = 'rgba(220, 38, 38, 0.35)',
         EVENT_BAR_STYLE = '#8d8',
         ACTIVITY_BAR_STYLE = 'rgba(170,170,255, 0.9)',
         OUTSIDE_EXPORT_RANGE_STYLE = 'rgba(100, 100, 100, 0.5)',
@@ -166,11 +170,12 @@ function SeekBar(canvas) {
         invalidateBackground();
     };
 
-    this.setActivity = function(newActivityTimes, newActivityStrengths, newHasEvent, newPIDProfile) {
+    this.setActivity = function(newActivityTimes, newActivityStrengths, newHasEvent, newPIDProfile, newGaps) {
         activityTime = newActivityTimes;
         activityStrength = newActivityStrengths;
         hasEvent = newHasEvent;
         pidProfile = newPIDProfile ?? [];
+        gaps = newGaps ?? [];
 
         invalidateBackground();
     };
@@ -192,6 +197,24 @@ function SeekBar(canvas) {
         }
 
         const pixelTimeStep = (max - min) / (canvas.width - BAR_INSET * 2);
+
+        if (gaps && gaps.length > 0) {
+            backgroundContext.fillStyle = GAP_STYLE;
+
+            for (const gap of gaps) {
+                const gapStart = Math.max(min, gap.startTime);
+                const gapEnd = Math.min(max, gap.endTime);
+
+                if (gapEnd <= gapStart) {
+                    continue;
+                }
+
+                const startX = (gapStart - min) / pixelTimeStep + BAR_INSET;
+                const endX = (gapEnd - min) / pixelTimeStep + BAR_INSET;
+
+                backgroundContext.fillRect(startX, 0, Math.max(1, endX - startX), canvas.height);
+            }
+        }
 
         if (activityTime.length > 0) {
             let time = min;


### PR DESCRIPTION
Since I have this broken Nexus-XR flash chip but the FC works without issues besides that, I thought it would be nice to at least view the rest of the BBL content instead of stopping at the first corrupt timestamp. 

If that is not wanted to be integrated into the standard, just let me know. 


<img width="1920" height="1009" alt="2026-05-03_17h08_48" src="https://github.com/user-attachments/assets/07e5bde4-5664-4d80-97b4-33d9aeb70ca5" />
