### PR TITLE
Uninstall Cleanup Message for Windows 

### DIFF
--- a/assets/windows/installer.iss
+++ b/assets/windows/installer.iss
@@ -108,3 +108,44 @@ begin
     end;
 
 end;
+
+function DirIsEmpty(const Path: string): Boolean;
+var
+  SR: TFindRec;
+begin
+  Result := True;
+  if FindFirst(Path + '\*', SR) then
+  try
+    repeat
+      if (SR.Name <> '.') and (SR.Name <> '..') then
+      begin
+        Result := False;
+        Break;
+      end;
+    until not FindNext(SR);
+  finally
+    FindClose(SR);
+  end;
+end;
+
+procedure CurUninstallStepChanged(UninstallStep: TUninstallStep);
+var
+  AppDir: String;
+begin
+  if UninstallStep = usPostUninstall then
+    begin
+        AppDir := ExpandConstant('{app}');
+        if DirExists(AppDir) then
+        begin
+            //Make sure the directory is actually empty
+            if not DirIsEmpty(AppDir) then
+            begin
+                MsgBox('Note: The folder "' + AppDir + '" contains files ' +
+                    'that were not removed.' + #13#10#13#10 +
+                    'Please delete this folder manually, before reinstalling Blackbox.',
+                    mbInformation, MB_OK);
+            end;
+        end;
+    end;
+end;
+


### PR DESCRIPTION
adding a message upon uninstall if the uninstaller is not able to clean up the install directory resulting in an incomplete uninstall.
This should reduce the instances of users installing new versions and not seeing the new versions because of a corrupt uninstall. 

Here is the new message upon uninstall if an issue is found,

<img width="533" height="238" alt="New_Message" src="https://github.com/user-attachments/assets/87156bb3-66d1-4e86-954c-9c8e37304eb9" />
